### PR TITLE
Transliterate non-ascii names using Unidecode

### DIFF
--- a/podcast_archiver.py
+++ b/podcast_archiver.py
@@ -42,6 +42,7 @@ from urllib.parse import urlparse
 import unicodedata
 import re
 import xml.etree.ElementTree as etree
+from unidecode import unidecode
 
 logger = logging.getLogger(__name__)
 
@@ -198,7 +199,7 @@ class PodcastArchiver:
         return self._feed_info_dict
 
     def slugify_string(filename):
-        filename = unicodedata.normalize('NFKD', filename).encode('ascii', 'ignore')
+        filename = unidecode(unicodedata.normalize('NFKD', filename)).encode('ascii', 'ignore')
         filename = re.sub('[^\w\s\-\.]', '', filename.decode('ascii')).strip()
         filename = re.sub('[-\s]+', '-', filename)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 feedparser>=5.2.1,<5.3
 tqdm>=4.14,<5.0
+Unidecode==1.1.1


### PR DESCRIPTION
Transliterate non-ascii names using [Unidecode](https://pypi.org/project/Unidecode/)

```python
>>> test = 'Примерно име'                                                                                                                                                                                         
>>> import unicodedata;                                                                                                                                                                                           
>>> from unidecode import unidecode                                                                                                                                                                               
>>> unicodedata.normalize('NFKD', test).encode('ascii', 'ignore')                                                                                                                                                 
b' '
>>> unidecode(unicodedata.normalize('NFKD', test)).encode('ascii', 'ignore')                                                                                                                                      
b'Primerno ime'
```